### PR TITLE
fix(cli): stop flag defaults from clobbering config-file values

### DIFF
--- a/src/skim/application/exporter/__init__.py
+++ b/src/skim/application/exporter/__init__.py
@@ -183,6 +183,7 @@ def save_drawings(
     outputs: OutputFiles,
     drawings: dict[str, draw.Drawing],
     render_engine: RenderEngine | None = None,
+    use_system_fonts: bool = False,
 ):
     if not outputs.force_overwrite:
         existing_files = []
@@ -210,5 +211,5 @@ def save_drawings(
         outputs.output_format,
         render_engine,
         convert_text_to_paths,
-        outputs.use_system_fonts,
+        use_system_fonts,
     )

--- a/src/skim/application/keymap_generator.py
+++ b/src/skim/application/keymap_generator.py
@@ -75,10 +75,10 @@ def _derive_default_config_from_keymap(keymap_path: Path) -> SkimConfig:
 
 def _get_config(
     config_path: Path | None,
-    use_system_fonts: bool = False,
+    use_system_fonts: bool | None = None,
     keymap_for_defaults: Path | None = None,
-    show_special_keys_legend: bool = True,
-    show_symbol_legend: bool = True,
+    show_special_keys_legend: bool | None = None,
+    show_symbol_legend: bool | None = None,
     symbol_legend_flow: str | None = None,
     symbol_legend_columns: int | None = None,
     macros_scale: float | None = None,
@@ -101,11 +101,18 @@ def _get_config(
         config_path: Path to the configuration YAML file, or None to use
             default configuration.
         use_system_fonts: Whether to use system fonts instead of embedding
-            fonts in the SVG output.
+            fonts in the SVG output. ``None`` means the CLI flag was not
+            given, so the config-file value is kept.
         keymap_for_defaults: When ``config_path`` is None, the keymap file used
             to derive default ``keyboard.layers`` and ``palette.layers`` so the
             generator behaves like the configurator does for an unconfigured
             keymap. Ignored when ``config_path`` is provided.
+        show_special_keys_legend: Whether to render the macro and tap-dance
+            legend tables. ``None`` means the CLI flag was not given, so the
+            config-file value is kept.
+        show_symbol_legend: Whether to render the symbol legend table.
+            ``None`` means the CLI flag was not given, so the config-file
+            value is kept.
         symbol_legend_flow: Override for the symbol legend flow direction
             (``"row"`` or ``"column"``).  ``None`` means use the config value.
 
@@ -143,13 +150,19 @@ def _get_config(
     )
 
     legends = config.output.style.legend_tables
-    macros_updates: dict = {"show": show_special_keys_legend}
+    macros_updates: dict = {}
+    if show_special_keys_legend is not None:
+        macros_updates["show"] = show_special_keys_legend
     if macros_scale is not None:
         macros_updates["scale"] = macros_scale
-    tap_dances_updates: dict = {"show": show_special_keys_legend}
+    tap_dances_updates: dict = {}
+    if show_special_keys_legend is not None:
+        tap_dances_updates["show"] = show_special_keys_legend
     if tap_dances_scale is not None:
         tap_dances_updates["scale"] = tap_dances_scale
-    symbols_updates: dict = {"show": show_symbol_legend}
+    symbols_updates: dict = {}
+    if show_symbol_legend is not None:
+        symbols_updates["show"] = show_symbol_legend
     if symbols_scale is not None:
         symbols_updates["scale"] = symbols_scale
     if symbol_legend_flow is not None:
@@ -166,9 +179,10 @@ def _get_config(
 
     style_updates: dict = {
         "palette": config.output.style.palette.model_copy(update={"layers": new_layers}),
-        "use_system_fonts": use_system_fonts,
         "legend_tables": new_legends,
     }
+    if use_system_fonts is not None:
+        style_updates["use_system_fonts"] = use_system_fonts
 
     new_style = config.output.style.model_copy(update=style_updates)
 
@@ -282,8 +296,8 @@ def generate_keymap(
     inputs: InputFiles,
     outputs: OutputFiles,
     targets: KeymapGeneratorTargets,
-    show_special_keys_legend: bool = True,
-    show_symbol_legend: bool = True,
+    show_special_keys_legend: bool | None = None,
+    show_symbol_legend: bool | None = None,
     symbol_legend_flow: str | None = None,
     symbol_legend_columns: int | None = None,
     macros_scale: float | None = None,
@@ -351,4 +365,9 @@ def generate_keymap(
         raw_keymap=input_keymap,
         keycode_mappings=keycode_mappings,
     )
-    save_drawings(outputs, drawings, outputs.render_engine)
+    save_drawings(
+        outputs,
+        drawings,
+        outputs.render_engine,
+        use_system_fonts=config.output.style.use_system_fonts,
+    )

--- a/src/skim/cli.py
+++ b/src/skim/cli.py
@@ -198,6 +198,7 @@ def doctor() -> None:
     "--use-system-fonts",
     "-F",
     is_flag=True,
+    default=None,
     help="Use system fonts instead of embedding fonts in SVG.",
 )
 @click.option(
@@ -217,7 +218,7 @@ def doctor() -> None:
     "--no-special-keys",
     "no_special_keys",
     is_flag=True,
-    default=False,
+    default=None,
     help="Omit the macro and tap-dance legend tables from the rendered SVGs.",
 )
 @click.option(
@@ -225,7 +226,7 @@ def doctor() -> None:
     "--no-symbols",
     "no_symbols",
     is_flag=True,
-    default=False,
+    default=None,
     help="Omit the symbol legend from the rendered SVGs.",
 )
 @click.option(
@@ -328,10 +329,10 @@ def generate(
     output_format: str,
     layer: tuple,
     force: bool,
-    use_system_fonts: bool,
+    use_system_fonts: bool | None,
     render_engine: str | None,
-    no_special_keys: bool,
-    no_symbols: bool,
+    no_special_keys: bool | None,
+    no_symbols: bool | None,
     symbol_legend_flow: str | None,
     symbol_legend_columns: int | None,
     macros_scale: float | None,
@@ -388,8 +389,8 @@ def generate(
             inputs,
             outputs,
             targets,
-            show_special_keys_legend=not no_special_keys,
-            show_symbol_legend=not no_symbols,
+            show_special_keys_legend=None if no_special_keys is None else not no_special_keys,
+            show_symbol_legend=None if no_symbols is None else not no_symbols,
             symbol_legend_flow=symbol_legend_flow,
             symbol_legend_columns=symbol_legend_columns,
             macros_scale=macros_scale,

--- a/src/skim/data/cli.py
+++ b/src/skim/data/cli.py
@@ -56,7 +56,8 @@ class OutputFiles:
         force_overwrite: Whether to overwrite existing files without
             prompting for confirmation. Defaults to False.
         use_system_fonts: Whether to use system fonts instead of embedding
-            fonts in SVG. Defaults to False.
+            fonts in SVG. ``None`` means the CLI flag was not given and the
+            config-file value should be kept. Defaults to ``None``.
         render_engine: Which render engine to use for non-vector formats.
             Options are CHROMIUM (Playwright) or CAIRO. If None, uses the
             first available engine. Defaults to None.
@@ -77,7 +78,7 @@ class OutputFiles:
     output_dir: Path = field(default_factory=Path)
     output_format: str = "svg"
     force_overwrite: bool = False
-    use_system_fonts: bool = False
+    use_system_fonts: bool | None = None
     render_engine: RenderEngine | None = None
 
 

--- a/tests/unit/application/test_keymap_generator.py
+++ b/tests/unit/application/test_keymap_generator.py
@@ -68,6 +68,96 @@ class TestGetConfig:
         mock_make_gradient.assert_called_once_with("#FF0000", layer.color_index)
         assert result.output.style.palette.layers[0].gradient is not None
 
+    def _config_with_style(self, **style_kwargs):
+        """Build a SkimConfig carrying the given output.style overrides."""
+        from skim.data.config import Output, Style
+
+        return SkimConfig(output=Output(style=Style(**style_kwargs)))
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_preserves_config_use_system_fonts_when_flag_absent(self, mock_load):
+        """Keeps the config-file use_system_fonts value when -F is not given.
+
+        Regression: the CLI flag default (False) used to clobber the
+        config-file value even when the flag was never passed.
+        """
+        mock_load.return_value = self._config_with_style(use_system_fonts=True)
+
+        result = _get_config(Path("config.yaml"))
+
+        assert result.output.style.use_system_fonts is True
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_use_system_fonts_flag_overrides_config(self, mock_load):
+        """-F turns system fonts on even when the config says False."""
+        mock_load.return_value = self._config_with_style(use_system_fonts=False)
+
+        result = _get_config(Path("config.yaml"), use_system_fonts=True)
+
+        assert result.output.style.use_system_fonts is True
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_use_system_fonts_flag_false_overrides_config(self, mock_load):
+        """Explicitly passing the flag as False still wins over the config."""
+        mock_load.return_value = self._config_with_style(use_system_fonts=True)
+
+        result = _get_config(Path("config.yaml"), use_system_fonts=False)
+
+        assert result.output.style.use_system_fonts is False
+
+    def _config_with_legends(self, macros_show=True, tap_dances_show=True, symbols_show=True):
+        """Build a SkimConfig with explicit legend-table visibility flags."""
+        from skim.data.config import (
+            LegendTables,
+            MacrosLegend,
+            SymbolsLegend,
+            TapDancesLegend,
+        )
+
+        legends = LegendTables(
+            macros=MacrosLegend(show=macros_show),
+            tap_dances=TapDancesLegend(show=tap_dances_show),
+            symbols=SymbolsLegend(show=symbols_show),
+        )
+        return self._config_with_style(legend_tables=legends)
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_preserves_config_legend_visibility_when_flags_absent(self, mock_load):
+        """Keeps config legend_tables.show values when -N/-Y are not given.
+
+        Regression: the CLI flag defaults (True) used to clobber the
+        config-file values even when the flags were never passed.
+        """
+        mock_load.return_value = self._config_with_legends(False, False, False)
+
+        result = _get_config(Path("config.yaml"))
+
+        assert result.output.style.legend_tables.macros.show is False
+        assert result.output.style.legend_tables.tap_dances.show is False
+        assert result.output.style.legend_tables.symbols.show is False
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_no_special_keys_flag_overrides_config_legend_visibility(self, mock_load):
+        """-N forces the macro/tap-dance legends off regardless of config."""
+        mock_load.return_value = self._config_with_legends(True, True, True)
+
+        result = _get_config(Path("config.yaml"), show_special_keys_legend=False)
+
+        assert result.output.style.legend_tables.macros.show is False
+        assert result.output.style.legend_tables.tap_dances.show is False
+        assert result.output.style.legend_tables.symbols.show is True
+
+    @patch("skim.application.keymap_generator.load_skim_config")
+    def test_no_symbols_flag_overrides_config_legend_visibility(self, mock_load):
+        """-Y forces the symbol legend off regardless of config."""
+        mock_load.return_value = self._config_with_legends(True, True, True)
+
+        result = _get_config(Path("config.yaml"), show_symbol_legend=False)
+
+        assert result.output.style.legend_tables.macros.show is True
+        assert result.output.style.legend_tables.tap_dances.show is True
+        assert result.output.style.legend_tables.symbols.show is False
+
     @patch("skim.application.keymap_generator.load_skim_config")
     def test_preserves_existing_gradients(self, mock_load):
         """Preserves layer colors that already have gradients."""
@@ -298,7 +388,12 @@ class TestGenerateKeymap:
         mock_draw_keymap.assert_called_once()
         draw_call_args, draw_call_kwargs = mock_draw_keymap.call_args
         assert draw_call_args[:3] == (mock_config, mock_resolved_keymap, targets)
-        mock_save_drawings.assert_called_once_with(outputs, mock_drawings, None)
+        mock_save_drawings.assert_called_once_with(
+            outputs,
+            mock_drawings,
+            None,
+            use_system_fonts=mock_config.output.style.use_system_fonts,
+        )
 
     @patch("skim.application.keymap_generator.logger")
     def test_exits_when_output_path_is_file(self, mock_logger, tmp_path):

--- a/tests/unit/data/test_cli.py
+++ b/tests/unit/data/test_cli.py
@@ -399,10 +399,14 @@ class TestOutputFilesWithRenderEngine:
         output = OutputFiles(render_engine=RenderEngine.CAIRO)
         assert output.render_engine == RenderEngine.CAIRO
 
-    def test_use_system_fonts_defaults_to_false(self):
-        """use_system_fonts defaults to False."""
+    def test_use_system_fonts_defaults_to_none(self):
+        """use_system_fonts defaults to None so config values are kept.
+
+        ``None`` means the CLI flag was not given; only an explicit
+        ``True``/``False`` overrides the config-file value.
+        """
         output = OutputFiles()
-        assert output.use_system_fonts is False
+        assert output.use_system_fonts is None
 
     def test_use_system_fonts_can_be_set(self):
         """use_system_fonts can be set to True."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -131,6 +131,50 @@ class TestGenerateCommand:
 
     @patch("skim.cli.generate_keymap")
     @patch("skim.cli.setup_logging")
+    def test_generate_absent_font_and_legend_flags_pass_none(
+        self, mock_setup, mock_generate, tmp_path
+    ):
+        """Absent -F/-N/-Y flags propagate as None so config values are kept.
+
+        Regression: the flags used to default to False/True and clobber the
+        config-file values even when never passed.
+        """
+        runner = CliRunner()
+        result = runner.invoke(main, ["generate", "-o", str(tmp_path)])
+
+        assert result.exit_code == 0
+        outputs = mock_generate.call_args.args[1]
+        assert outputs.use_system_fonts is None
+        assert mock_generate.call_args.kwargs["show_special_keys_legend"] is None
+        assert mock_generate.call_args.kwargs["show_symbol_legend"] is None
+
+    @patch("skim.cli.generate_keymap")
+    @patch("skim.cli.setup_logging")
+    def test_generate_use_system_fonts_flag_propagates_true(
+        self, mock_setup, mock_generate, tmp_path
+    ):
+        """-F propagates True through OutputFiles."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["generate", "-F", "-o", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert mock_generate.call_args.args[1].use_system_fonts is True
+
+    @patch("skim.cli.generate_keymap")
+    @patch("skim.cli.setup_logging")
+    def test_generate_no_special_keys_and_no_symbols_flags_propagate_false(
+        self, mock_setup, mock_generate, tmp_path
+    ):
+        """-N and -Y propagate False through the legend visibility kwargs."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["generate", "-N", "-Y", "-o", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert mock_generate.call_args.kwargs["show_special_keys_legend"] is False
+        assert mock_generate.call_args.kwargs["show_symbol_legend"] is False
+
+    @patch("skim.cli.generate_keymap")
+    @patch("skim.cli.setup_logging")
     def test_generate_handles_abort(self, mock_setup, mock_generate):
         """Handles click.Abort gracefully."""
         mock_generate.side_effect = click.Abort()


### PR DESCRIPTION
# PR: fix(cli): stop flag defaults from clobbering config-file values

**Base branch:** `mainline`
**Branch:** `fix/cli-flag-config-overrides`
**Commit:** `e8930a8` (patch: `/tmp/opencode/skim-fix.patch`)

## Summary

When a config file is loaded with `skim generate -c <file>`, three CLI flags
unconditionally overwrite the corresponding config-file values even when the
flag is **not** passed on the command line:

- `-F/--use-system-fonts` -> clobbers `output.style.use_system_fonts`
- `-N/--no-special-keys` -> clobbers `output.style.legend_tables.macros/tap_dances.show`
- `-Y/--no-symbols` -> clobbers `output.style.legend_tables.symbols.show`

Because the flags defaulted to `False`/`True` (not `None`), "flag absent" was
indistinguishable from "user explicitly passed the default", so
`_get_config()` had no way to know it should keep the config value.

## Repro

```yaml
# skimconfig.yaml
output:
  style:
    use_system_fonts: true
```

```bash
skim generate -c skimconfig.yaml -k keyboard.kbi -o layout/ --layer 0-3
grep -c @font-face layout/keymap-layer-1.svg   # -> 5 (fonts embedded anyway)
```

Expected: `0` (config honored without `-F`). Same for
`legend_tables.*.show: false` vs `-N`/`-Y`.

## Fix

Make the three flags tri-state (`None` = not given) and only apply them in
`_get_config()` when not `None`.

- `src/skim/cli.py` — `--use-system-fonts`, `-N/--no-special-keys`,
  `-Y/--no-symbols` click options now `default=None`; `generate()` signature
  and the `generate_keymap()` call site pass `None` through for absent flags.
- `src/skim/data/cli.py` — `OutputFiles.use_system_fonts` defaults to `None`.
- `src/skim/application/keymap_generator.py` — `_get_config()` only applies
  `use_system_fonts`, `show_special_keys_legend`, and `show_symbol_legend`
  when the argument is not `None`; `generate_keymap()` widens the two legend
  params to `bool | None`.
- `src/skim/application/exporter/__init__.py` — `save_drawings()` now takes
  the resolved `use_system_fonts` value (previously it re-read the raw CLI
  value, so cairo/PNG export would ignore the config).

## Tests

- `tests/unit/application/test_keymap_generator.py` — precedence matrix for
  `_get_config()`: config value preserved when flag absent; explicit
  `True`/`False` still wins.
- `tests/unit/test_cli.py` — absent flags propagate as `None`; `-F`, `-N`,
  `-Y` propagate their values.
- `tests/unit/data/test_cli.py` — `OutputFiles.use_system_fonts` default is
  now `None`.

## Verification

- `uv run pytest tests/unit` — 1410 passed, 1 skipped (81.61% coverage, meets 80%)
- `uv run ruff check src tests` — clean
- `uv run ruff format --check src tests` — clean
- `uv run basedpyright src` — 0 errors
- Manual:
  - config `use_system_fonts: true`, no flag -> `@font-face` count 0
  - `-F` flag -> `@font-face` count 0
  - no config, no flag -> `@font-face` count 5 (defaults unchanged)
